### PR TITLE
Inject a build dependency for the builder class for generic Build.pm …

### DIFF
--- a/lib/App/ecogen.pm6
+++ b/lib/App/ecogen.pm6
@@ -53,7 +53,12 @@ role Ecosystem {
         for <depends build-depends test-depends> {
             $meta{$_} = $meta{$_}.grep(*.defined).map({
                 $_ ~~ Hash ?? $_<name> !! $_
-            }).grep({$_ !~~ /':from'/}) if $meta{$_}:exists;
+            }).grep({$_ !~~ /':from'/}).Array if $meta{$_}:exists;
+        }
+
+        if $meta<builder>:exists {
+            $meta<build-depends> //= [];
+            $meta<build-depends>.push: "Distribution::Builder::$meta<builder>";
         }
     }
 


### PR DESCRIPTION
…support

For old versions of zef, distros may ship a generic Build.pm that just
loads the appropriate Distribution::Builder and runs that. But we need
to ensure that it's actually installed, so we inject it into the
build-depends.
New zef versions will read the meta-version 1 data and know about the
"builder" key right away.