### PR TITLE
use a cpan rsync mirror if main one is down

### DIFF
--- a/lib/App/ecogen/cpan.pm6
+++ b/lib/App/ecogen/cpan.pm6
@@ -17,7 +17,7 @@ class App::ecogen::cpan does Ecosystem {
                 $meta-list-uri, 'CPAN';
             my $indexing-proc = shell @command.join(' '), :out, :env(%*ENV);
             my $meta-uri-parts := $indexing-proc.out.slurp-rest(:close).lines.grep(*.ends-with('.meta'));
-            my @meta-uris = $meta-uri-parts.grep({ !$_.starts-with('id/P/PS/PSIXDISTS/') }).map({ "http://www.cpan.org/authors/$_" });
+            @meta-uris = $meta-uri-parts.grep({ !$_.starts-with('id/P/PS/PSIXDISTS/') }).map({ "http://www.cpan.org/authors/$_" });
             last;
             CATCH {
                 default {

--- a/lib/App/ecogen/cpan.pm6
+++ b/lib/App/ecogen/cpan.pm6
@@ -3,21 +3,28 @@ use App::ecogen;
 
 class App::ecogen::cpan does Ecosystem {
     has $.prefix;
-    has $!meta-list-uri = 'cpan-rsync.perl.org::CPAN/authors/id';
+    has @!meta-list-uris = 'cpan-rsync.perl.org::CPAN/authors/id', 'ftp-stud.hs-esslingen.de::CPAN/authors/id';
 
     method IO { self.prefix.IO }
 
     method meta-uris {
-        my @command = '/usr/bin/rsync', '--dry-run', '--prune-empty-dirs', '-av', 
-            '--include="/id/*/*/*/Perl6/"',      '--include="/id/*/*/*/Perl6/*.meta"', '--include="/id/*/*/*/Perl6/*.tar.gz"',
-            '--include="/id/*/*/*/Perl6/*.tgz"', '--include="/id/*/*/*/Perl6/*.zip"',  '--exclude="/id/*/*/*/Perl6/*"',
-            '--exclude="/id/*/*/*/*"',           '--exclude="id/*/*/CHECKSUMS"',       '--exclude="id/*/CHECKSUMS"',
-            $!meta-list-uri, 'CPAN';
-
-        my $indexing-proc = shell @command.join(' '), :out, :env(%*ENV);
-        my $meta-uri-parts := $indexing-proc.out.slurp-rest(:close).lines.grep(*.ends-with('.meta'));
-        my @meta-uris = $meta-uri-parts.grep({ !$_.starts-with('id/P/PS/PSIXDISTS/') }).map({ "http://www.cpan.org/authors/$_" });
-
+        my @meta-uris;
+        for @!meta-list-uris -> $meta-list-uri {
+            my @command = '/usr/bin/rsync', '--dry-run', '--prune-empty-dirs', '-av', 
+                '--include="/id/*/*/*/Perl6/"',      '--include="/id/*/*/*/Perl6/*.meta"', '--include="/id/*/*/*/Perl6/*.tar.gz"',
+                '--include="/id/*/*/*/Perl6/*.tgz"', '--include="/id/*/*/*/Perl6/*.zip"',  '--exclude="/id/*/*/*/Perl6/*"',
+                '--exclude="/id/*/*/*/*"',           '--exclude="id/*/*/CHECKSUMS"',       '--exclude="id/*/CHECKSUMS"',
+                $meta-list-uri, 'CPAN';
+            my $indexing-proc = shell @command.join(' '), :out, :env(%*ENV);
+            my $meta-uri-parts := $indexing-proc.out.slurp-rest(:close).lines.grep(*.ends-with('.meta'));
+            my @meta-uris = $meta-uri-parts.grep({ !$_.starts-with('id/P/PS/PSIXDISTS/') }).map({ "http://www.cpan.org/authors/$_" });
+            last;
+            CATCH {
+                default {
+                    next;
+                }
+            }
+        }
         @meta-uris;
     }
 }


### PR DESCRIPTION
like it is right now. this is the same mirror i put into modules.perl6.org,
so that both would fail consistently, and noticing one is broken lets us
immediately know to fix the other one as well.

Could potentially grab the mirrors list as json and go through all rsync
mirrors, but for now this should be good enough.